### PR TITLE
New test case for repeated task mapping children

### DIFF
--- a/casemodels/bin/repeat_with_mapping.xml
+++ b/casemodels/bin/repeat_with_mapping.xml
@@ -1,0 +1,83 @@
+<definitions>
+    <case id="repeat_with_mapping.case" name="repeat_with_mapping" expressionLanguage="spel">
+        <caseFileModel>
+            <caseFileItem id="_OgBIe_3" name="Child" multiplicity="ZeroOrMore" definitionRef="childitem.cfid">
+                <children>
+                    <caseFileItem id="_OgBIe_2" name="GrandChild" multiplicity="ExactlyOne" definitionRef="grandchilditem.cfid"/>
+                </children>
+            </caseFileItem>
+        </caseFileModel>
+        <casePlanModel id="cm__OgBIe_0" name="repeat_with_mapping" autoComplete="true">
+            <planItem id="pi_ht__OgBIe_0" name="Create Children" definitionRef="ht__OgBIe_0"/>
+            <planItem id="pi_ht__OgBIe_1" name="Edit GrandChild" definitionRef="ht__OgBIe_1">
+                <entryCriterion id="_OgBIe_11" name="EntryCriterion_0" sentryRef="crit__OgBIe_0"/>
+                <itemControl id="_OgBIe_1">
+                    <repetitionRule id="_OgBIe_9">
+                        <condition id="_OgBIe_10">
+                            <body>
+                                <![CDATA[true]]>
+                            </body>
+                        </condition>
+                    </repetitionRule>
+                </itemControl>
+            </planItem>
+            <sentry id="crit__OgBIe_0">
+                <caseFileItemOnPart id="_OgBIe_12" sourceRef="_OgBIe_3">
+                    <standardEvent>create</standardEvent>
+                </caseFileItemOnPart>
+            </sentry>
+            <humanTask id="ht__OgBIe_0" name="Create Children" isBlocking="true">
+                <outputs id="_OgBIe_18" name="Child" bindingRef="_OgBIe_3"/>
+                <extensionElements mustUnderstand="false">
+                    <cafienne:implementation name="createfamily" xmlns:cafienne="org.cafienne" class="org.cafienne.cmmn.definition.task.WorkflowTaskDefinition" humanTaskRef="createfamily.humantask">
+                        <output id="_2Fqq_children" name="children"/>
+                        <parameterMapping id="_OgBIe_8" sourceRef="_2Fqq_children" targetRef="_OgBIe_18"/>
+                    </cafienne:implementation>
+                </extensionElements>
+            </humanTask>
+            <humanTask id="ht__OgBIe_1" name="Edit GrandChild" isBlocking="true">
+                <inputs id="_OgBIe_15" name="Child" bindingRef="_OgBIe_3"/>
+                <extensionElements mustUnderstand="false">
+                    <cafienne:implementation name="editgrandchild" xmlns:cafienne="org.cafienne" class="org.cafienne.cmmn.definition.task.WorkflowTaskDefinition" humanTaskRef="editgrandchild.humantask">
+                        <input id="_jF8a_GrandChildItem" name="GrandChild"/>
+                        <parameterMapping id="_OgBIe_13" sourceRef="_OgBIe_15" targetRef="_jF8a_GrandChildItem">
+                            <transformation id="_OgBIe_16">
+                                <body>
+                                    <![CDATA[Child.GrandChild]]>
+                                </body>
+                            </transformation>
+                        </parameterMapping>
+                    </cafienne:implementation>
+                </extensionElements>
+            </humanTask>
+        </casePlanModel>
+    </case>
+    <caseFileItemDefinition name="childitem" definitionType="http://www.omg.org/spec/CMMN/DefinitionType/Unspecified" id="childitem.cfid">
+        <property name="ChildName" type="http://www.omg.org/spec/CMMN/PropertyType/string"/>
+        <property name="ChildAge" type="http://www.omg.org/spec/CMMN/PropertyType/integer"/>
+    </caseFileItemDefinition>
+    <caseFileItemDefinition name="grandchilditem" definitionType="http://www.omg.org/spec/CMMN/DefinitionType/Unspecified" id="grandchilditem.cfid">
+        <property name="GrandChildName" type="http://www.omg.org/spec/CMMN/PropertyType/string"/>
+        <property name="GrandChildBirthDate" type="http://www.omg.org/spec/CMMN/PropertyType/date"/>
+    </caseFileItemDefinition>
+    <CMMNDI>
+        <CMMNDiagram>
+            <CMMNShape cmmnElementRef="cm__OgBIe_0">
+                <Bounds x="20" y="20" width="800" height="500"/>
+            </CMMNShape>
+            <CMMNShape cmmnElementRef="pi_ht__OgBIe_0">
+                <Bounds x="110" y="140" width="140" height="80"/>
+            </CMMNShape>
+            <CMMNShape cmmnElementRef="pi_ht__OgBIe_1">
+                <Bounds x="440" y="140" width="140" height="80"/>
+            </CMMNShape>
+            <CMMNShape cmmnElementRef="_OgBIe_3">
+                <Bounds x="320" y="160" width="25" height="40"/>
+            </CMMNShape>
+            <CMMNShape cmmnElementRef="_OgBIe_11">
+                <Bounds x="434" y="170" width="12" height="20"/>
+            </CMMNShape>
+            <CMMNEdge sourceCMMNElementRef="_OgBIe_3" targetCMMNElementRef="_OgBIe_11"/>
+        </CMMNDiagram>
+    </CMMNDI>
+</definitions>

--- a/casemodels/src/createfamily.humantask
+++ b/casemodels/src/createfamily.humantask
@@ -1,0 +1,5 @@
+<humantask>
+    <cafienne:implementation name="createfamily" xmlns:cafienne="org.cafienne" class="org.cafienne.cmmn.definition.task.WorkflowTaskDefinition">
+        <output id="_2Fqq_children" name="children"/>
+    </cafienne:implementation>
+</humantask>

--- a/casemodels/src/editgrandchild.humantask
+++ b/casemodels/src/editgrandchild.humantask
@@ -1,0 +1,5 @@
+<humantask>
+    <cafienne:implementation name="editgrandchild" xmlns:cafienne="org.cafienne" class="org.cafienne.cmmn.definition.task.WorkflowTaskDefinition">
+        <input id="_jF8a_GrandChildItem" name="GrandChild"/>
+    </cafienne:implementation>
+</humantask>

--- a/casemodels/src/repeat_with_mapping.case
+++ b/casemodels/src/repeat_with_mapping.case
@@ -1,0 +1,51 @@
+<case id="repeat_with_mapping.case" name="repeat_with_mapping" expressionLanguage="spel" guid="_OgBIe">
+    <caseFileModel>
+        <caseFileItem id="_OgBIe_3" name="Child" multiplicity="ZeroOrMore" definitionRef="childitem.cfid">
+            <children>
+                <caseFileItem id="_OgBIe_2" name="GrandChild" multiplicity="ExactlyOne" definitionRef="grandchilditem.cfid"/>
+            </children>
+        </caseFileItem>
+    </caseFileModel>
+    <casePlanModel id="cm__OgBIe_0" name="repeat_with_mapping" autoComplete="true">
+        <planItem id="pi_ht__OgBIe_0" name="Create Children" definitionRef="ht__OgBIe_0"/>
+        <planItem id="pi_ht__OgBIe_1" name="Edit GrandChild" definitionRef="ht__OgBIe_1">
+            <entryCriterion id="_OgBIe_11" name="EntryCriterion_0" sentryRef="crit__OgBIe_0"/>
+            <itemControl id="_OgBIe_1">
+                <repetitionRule id="_OgBIe_9">
+                    <condition id="_OgBIe_10">
+                        <body>
+                            <![CDATA[true]]>
+                        </body>
+                    </condition>
+                </repetitionRule>
+            </itemControl>
+        </planItem>
+        <sentry id="crit__OgBIe_0">
+            <caseFileItemOnPart id="_OgBIe_12" sourceRef="_OgBIe_3">
+                <standardEvent>create</standardEvent>
+            </caseFileItemOnPart>
+        </sentry>
+        <humanTask id="ht__OgBIe_0" name="Create Children" isBlocking="true">
+            <outputs id="_OgBIe_18" name="Child" bindingRef="_OgBIe_3"/>
+            <extensionElements mustUnderstand="false">
+                <cafienne:implementation xmlns:cafienne="org.cafienne" humanTaskRef="createfamily.humantask">
+                    <parameterMapping id="_OgBIe_8" sourceRef="_2Fqq_children" targetRef="_OgBIe_18"/>
+                </cafienne:implementation>
+            </extensionElements>
+        </humanTask>
+        <humanTask id="ht__OgBIe_1" name="Edit GrandChild" isBlocking="true">
+            <inputs id="_OgBIe_15" name="Child" bindingRef="_OgBIe_3"/>
+            <extensionElements mustUnderstand="false">
+                <cafienne:implementation xmlns:cafienne="org.cafienne" humanTaskRef="editgrandchild.humantask">
+                    <parameterMapping id="_OgBIe_13" sourceRef="_OgBIe_15" targetRef="_jF8a_GrandChildItem">
+                        <transformation id="_OgBIe_16">
+                            <body>
+                                <![CDATA[Child.GrandChild]]>
+                            </body>
+                        </transformation>
+                    </parameterMapping>
+                </cafienne:implementation>
+            </extensionElements>
+        </humanTask>
+    </casePlanModel>
+</case>

--- a/casemodels/src/repeat_with_mapping.dimensions
+++ b/casemodels/src/repeat_with_mapping.dimensions
@@ -1,0 +1,20 @@
+<CMMNDI>
+    <CMMNDiagram>
+        <CMMNShape cmmnElementRef="cm__OgBIe_0">
+            <Bounds x="20" y="20" width="800" height="500"/>
+        </CMMNShape>
+        <CMMNShape cmmnElementRef="pi_ht__OgBIe_0">
+            <Bounds x="110" y="140" width="140" height="80"/>
+        </CMMNShape>
+        <CMMNShape cmmnElementRef="pi_ht__OgBIe_1">
+            <Bounds x="440" y="140" width="140" height="80"/>
+        </CMMNShape>
+        <CMMNShape cmmnElementRef="_OgBIe_3">
+            <Bounds x="320" y="160" width="25" height="40"/>
+        </CMMNShape>
+        <CMMNShape cmmnElementRef="_OgBIe_11">
+            <Bounds x="434" y="170" width="12" height="20"/>
+        </CMMNShape>
+        <CMMNEdge sourceCMMNElementRef="_OgBIe_3" targetCMMNElementRef="_OgBIe_11"/>
+    </CMMNDiagram>
+</CMMNDI>

--- a/src/app.ts
+++ b/src/app.ts
@@ -40,6 +40,7 @@ import TestCasePlanHistoryAPI from './tests/api/caseplan/testcaseplanhistoryapi'
 import TestTaskFilterAPI from './tests/api/task/testtaskfilterapi';
 import TestTaskExpressions from './tests/api/expression/testtaskexpressions';
 import TestProcessTask from './tests/api/caseplan/task/testprocesstask';
+import TestRepeatWithMapping from './tests/api/expression/testrepeatwithmapping';
 
 
 function findTestsFromCommandLineArguments(): Array<string> {
@@ -125,6 +126,7 @@ const AllTestCases = new TestClasses([
     , TestCasePlanAPI
     , TestCasePlanHistoryAPI
     , TestBusinessIdentifiers
+    , TestRepeatWithMapping
     , TestTaskExpressions
     , TestProcessTask
     , TestCaseTeamAPI

--- a/src/framework/service/task/taskservice.ts
+++ b/src/framework/service/task/taskservice.ts
@@ -106,13 +106,10 @@ export default class TaskService {
      * @param task
      * @param user 
      */
-    async getTask(user: User, task: Task, expectedStatusCode: number = 200): Promise<Task> {
-        if (!task.id) {
-            console.log("Oops. First try to succesfully start a case ?!");
-            return task;
-        }
-        const response = await cafienneService.get('tasks/' + task.id, user);
-        const msg = `GetTask is not expected to succeed for user ${user.id} on task ${task.id}`;
+    async getTask(user: User, task: Task | string, expectedStatusCode: number = 200): Promise<Task> {
+        const taskId = (typeof(task) === 'string') ? task : task.id;
+        const response = await cafienneService.get('tasks/' + taskId, user);
+        const msg = `GetTask is not expected to succeed for user ${user.id} on task ${taskId}`;
         return await checkJSONResponse(response, msg, expectedStatusCode);
     }
 

--- a/src/framework/test/assertions.ts
+++ b/src/framework/test/assertions.ts
@@ -100,7 +100,7 @@ export async function assertCasePlanState(user: User, caseInstance: Case, state:
  */
 export function verifyTaskInput(task: Task, taskInput: any) {
     if (!Comparison.sameJSON(task.input, taskInput)) {
-        throw new Error('Task input is not the same as given to the case');
+        throw new Error(`Input for task ${task.taskName} is not expected;\nFound:    ${JSON.stringify(task.input)}\nExpected: ${JSON.stringify(taskInput)}`);
     }
 }
 

--- a/src/tests/api/expression/testrepeatwithmapping.ts
+++ b/src/tests/api/expression/testrepeatwithmapping.ts
@@ -1,0 +1,83 @@
+'use strict';
+
+import CaseService from '../../../framework/service/case/caseservice';
+import TaskService from '../../../framework/service/task/taskservice';
+import TestCase from '../../../framework/test/testcase';
+import WorldWideTestTenant from '../../worldwidetesttenant';
+import RepositoryService from '../../../framework/service/case/repositoryservice';
+import Case from '../../../framework/cmmn/case';
+import { assertCaseFileContent } from '../../../framework/test/assertions';
+import { verifyTaskInput } from '../../../framework/test/assertions';
+import CasePlanService from '../../../framework/service/case/caseplanservice';
+import PlanItem from '../../../framework/cmmn/planitem';
+
+const repositoryService = new RepositoryService();
+const definition = 'repeat_with_mapping.xml';
+
+const caseService = new CaseService();
+const casePlanService = new CasePlanService();
+const taskService = new TaskService();
+const worldwideTenant = new WorldWideTestTenant();
+const tenant = worldwideTenant.name;
+const user = worldwideTenant.sender;
+
+export default class TestRepeatWithMapping extends TestCase {
+    async onPrepareTest() {
+        await worldwideTenant.create();
+        await repositoryService.validateAndDeploy(user, definition, tenant);
+    }
+
+    async run() {
+        const startCase = { tenant, definition };
+        const caseInstance = await caseService.startCase(user, startCase) as Case;
+
+        const firstTaskName = 'Create Children';
+        const secondTaskName = 'Edit GrandChild';
+        const firstGrandChild = {
+            GrandChildName: 'Little John',
+            GrandChildBirthDate: '2019-10-26'
+        };
+        const secondGrandChild = {
+            GrandChildName: 'Little Pete',
+            GrandChildBirthDate: '2016-10-26'
+        };
+        const taskOutput = [{
+            ChildName: 'John',
+            ChildAge: 23,
+            GrandChild: firstGrandChild
+        }, {
+            ChildName: 'Pete',
+            ChildAge: 26,
+            GrandChild: secondGrandChild
+        }];
+
+        const task = (await taskService.getCaseTasks(user, caseInstance)).find(task => {
+            if (task.taskName === firstTaskName) console.log("Found task '" + firstTaskName + "' in state " + task.taskState)
+            return task.taskName === firstTaskName && task.taskState !== 'Completed'
+        });
+        if (!task) {
+            throw new Error('There is no Active instance of task ' + firstTaskName);
+        }
+        console.log(`Invoking ${firstTaskName} with ${JSON.stringify(taskOutput)}`)
+        await taskService.completeTask(user, task, { children: taskOutput });
+
+        await assertCaseFileContent(user, caseInstance, 'Child', taskOutput);
+
+        // Get the two second tasks, named 'Edit Grand Child'.
+        const planItems = (await casePlanService.getPlanItems(user, caseInstance)).filter(item => item.name === secondTaskName);
+        if (planItems.length !== 2) {
+            throw new Error(`Expecting 2 tasks with name ${secondTaskName}`);
+        }
+
+        // Validate both their input parameters
+        const validateTask = async (item: PlanItem) => {
+            const task = await taskService.getTask(user, item.id);
+            const expectedTaskInput = item.index === 0 ? firstGrandChild : secondGrandChild;
+            verifyTaskInput(task, { GrandChild: expectedTaskInput});
+        }
+        await validateTask(planItems[0]);
+        await validateTask(planItems[1]);
+
+        console.log('\n\n\tCase ID:\t\t' + caseInstance.id);
+    }
+}


### PR DESCRIPTION
When a task repeats upon case file creation for an array item, then in the input mappings, if we access a child of the array it will give a null object in the engine. This test case asserts that this should not be the case.