### PR TITLE
Change tests to run with new task authorizations

### DIFF
--- a/src/infra/testclasses.ts
+++ b/src/infra/testclasses.ts
@@ -48,6 +48,7 @@ import TestCaseTeamAPI from '../tests/api/caseteam/testcaseteamapi';
 import TestCaseTeamAuthorizations from '../tests/api/caseteam/testcaseteamauthorizations';
 import TestCaseTeamConsentGroupAPI from '../tests/api/caseteam/testcaseteamconsentgroupapi';
 import TestCaseTeamTaskAuthorizations from '../tests/api/caseteam/testcaseteamtaskauthorizations';
+import TestCaseTeamTaskAuthorizationsForGroups from '../tests/api/caseteam/testcaseteamtaskauthorizationsforgroups';
 import TestCaseTeamTenantRoleMembers from '../tests/api/caseteam/testcaseteamtenantrolemembers';
 import TestStartCaseEmptyRole from '../tests/api/caseteam/teststartcaseemptyrole';
 import TestTenantGroupMembership from '../tests/api/caseteam/testtenantgroupmembership';
@@ -210,6 +211,7 @@ const AllTests: Array<Function> = [
     , TestCaseTeamTenantRoleMembers
     , TestCaseTeamConsentGroupAPI
     , TestCaseTeamTaskAuthorizations
+    , TestCaseTeamTaskAuthorizationsForGroups
     , TestCaseTeamAuthorizations
     , TestEventAuthorization
     , TestArchiveHelloworld

--- a/src/test/testcase.ts
+++ b/src/test/testcase.ts
@@ -61,6 +61,10 @@ export default class TestCase {
 
     }
 
+    fail(msg = 'Failing the test at this point') {
+        throw new Error(msg);
+    }
+
     /**
      * Simplistic mechanism to enable manual breakpoints and user inputs while running tests
      * @param question String to be printed on console

--- a/src/tests/api/archiving/testdeletecaseauthorization.ts
+++ b/src/tests/api/archiving/testdeletecaseauthorization.ts
@@ -13,7 +13,7 @@ import PlatformService from '../../../service/platform/platformservice';
 import CaseEvents from '../../../service/storage/caseevents';
 import StorageService from '../../../service/storage/storageservice';
 import Tenant from '../../../tenant/tenant';
-import TenantUser, { TenantOwner } from '../../../tenant/tenantuser';
+import { TenantOwner } from '../../../tenant/tenantuser';
 import TestCase from '../../../test/testcase';
 import Util from '../../../test/util';
 import WorldWideTestTenant from '../../setup/worldwidetesttenant';

--- a/src/tests/api/caseteam/testcaseteamauthorizations.ts
+++ b/src/tests/api/caseteam/testcaseteamauthorizations.ts
@@ -97,26 +97,26 @@ export default class TestCaseTeamAuthorizations extends TestCase {
         await this.validateRolelessTaskAccess(caseInstance);
     }
 
-    async validateRequestTaskAccess(caseInstance: Case|string) {
+    async validateRequestTaskAccess(caseInstance: Case | string) {
         // Jeff is owner of the mars group, and is allowed to Assign and Delegate the task.
         //  Boy is case owner, but the request task is exclusive to the mars group, and therefore he cannot assign the task
         //  Also he is mars group member, but not mars group owner, so also therefore he cannot assign the task.
         const taskPerformers: Array<User> = [universe.boy];
         const taskManagers: Array<User> = [universe.jeff];
 
-        await this.validateTaskAccess(caseInstance, requestTask, taskPerformers, taskManagers);        
+        await this.validateTaskAccess(caseInstance, requestTask, taskPerformers, taskManagers);
     }
 
-    async validateApproveTaskAccess(caseInstance: Case|string) {
+    async validateApproveTaskAccess(caseInstance: Case | string) {
         // Approve task is only available to tenant user with 'Family' role.
         // Boy is case owner and can therefore manage the task
         const taskPerformers: Array<User> = familyCaseMembers;
         const taskManagers: Array<User> = [universe.boy];
 
-        await this.validateTaskAccess(caseInstance, approveTask, taskPerformers, taskManagers);        
+        await this.validateTaskAccess(caseInstance, approveTask, taskPerformers, taskManagers);
     }
 
-    async validateParticipantTaskAccess(caseInstance: Case|string) {
+    async validateParticipantTaskAccess(caseInstance: Case | string) {
         // The whole case team, except for the mars2Group, has the participant role and should be able to access the task.
         const taskPerformers = [...familyCaseMembers, ...moonGroupCaseMembers, ...marsGroupCaseMembers];
         // Boy is case owner, neil owns moonGroup and jeff owns marsGroup
@@ -125,7 +125,7 @@ export default class TestCaseTeamAuthorizations extends TestCase {
         await this.validateTaskAccess(caseInstance, participantTask, taskPerformers, taskManagers);
     }
 
-    async validateAssistTaskAccess(caseInstance: Case|string) {
+    async validateAssistTaskAccess(caseInstance: Case | string) {
         // The assist task can be taken by both case owners and moonmen that are moontester or owner of the moongroup.
         const taskManagers = [universe.boy, universe.neil]; // Case owner and consent group owner
         const taskPerformers = [universe.dad, universe.alien]; // Users with role 'PersonalAssistant'
@@ -133,7 +133,7 @@ export default class TestCaseTeamAuthorizations extends TestCase {
         await this.validateTaskAccess(caseInstance, assistTask, taskPerformers, taskManagers);
     }
 
-    async validateRolelessTaskAccess(caseInstance: Case|string) {
+    async validateRolelessTaskAccess(caseInstance: Case | string) {
         // All case team members should be able to access a task without a caseRole
         const taskPerformers = caseTeamMembers;
         // boy is both case owner from tenant perspective and group owner of marsGroup2
@@ -143,7 +143,7 @@ export default class TestCaseTeamAuthorizations extends TestCase {
         await this.validateTaskAccess(caseInstance, taskWithoutRole, taskPerformers, taskManagers);
     }
 
-    async validateCaseQueryAccess(caseInstance: Case|string) {
+    async validateCaseQueryAccess(caseInstance: Case | string) {
         const usersWithCaseAccess = caseTeamMembers;
         const usersWithoutCaseAccess = universe.people.filter(person => caseTeamMembers.filter(user => user.id === person.id).length === 0);
 
@@ -158,7 +158,7 @@ export default class TestCaseTeamAuthorizations extends TestCase {
         };
     }
 
-    async validateCaseCommandAccess(caseInstance: Case|string) {
+    async validateCaseCommandAccess(caseInstance: Case | string) {
         const usersWithCaseAccess = caseTeamMembers;
         const usersWithoutCaseAccess = universe.people.filter(person => caseTeamMembers.filter(user => user.id === person.id).length === 0);
 
@@ -178,17 +178,7 @@ export default class TestCaseTeamAuthorizations extends TestCase {
         if (!task) {
             throw new Error(`Cannot find an active task ${taskName} in case ${caseInstance}`)
         }
-        const taskUsers = [...taskManagers, ...taskPerformers];
-
-        await this.validateTaskPerformers(task, taskUsers);
-
-        const assignee = taskPerformers[0];
-        await this.validateTaskManagers(task, assignee, taskManagers, taskPerformers);
-    }
-
-    async validateTaskPerformers(task: PlanItem, usersWithTaskAccess: Array<User>, usersWithoutTaskAccess = caseTeamMembers.filter(member => !usersWithTaskAccess.find(user => user.id === member.id))) {
-        // const usersWithoutTaskAccess = caseTeamMembers.filter(member => !usersWithTaskAccess.find(user => user.id === member.id));
-        const taskName = task.name;
+        const usersWithTaskAccess = [...taskManagers, ...taskPerformers];
 
         for (const user of usersWithTaskAccess) {
             console.log(`\nChecking whether user ${user} has access to task ${taskName}`);
@@ -197,28 +187,10 @@ export default class TestCaseTeamAuthorizations extends TestCase {
             await TaskService.getTask(user, task).then(task => console.log("Task state is: " + task.taskState));
         };
 
+        const usersWithoutTaskAccess = caseTeamMembers.filter(member => !usersWithTaskAccess.find(user => user.id === member.id));
         for (const user of usersWithoutTaskAccess) {
             console.log(`\nChecking whether user ${user} has access to task ${taskName}`);
             await TaskService.claimTask(user, task, 401, `Not expected that user ${user} has access to claim task ${taskName}`);
-        };
-    }
-
-    async validateTaskManagers(task: PlanItem, assignee: User, taskManagers: Array<User>, others: Array<User>) {
-        // Just filter out task managers from others
-        others = others.filter(possibleManager => ! taskManagers.find(manager => manager.id === possibleManager.id));
-
-        const taskName = task.name;
-        for (const user of taskManagers) {
-            console.log(`\nChecking whether user ${user} is allowed to manage task ${taskName}`);
-            if (assignee) {
-                await TaskService.assignTask(user, task, assignee, 202, `Expected user ${user} to have access to assign task ${taskName}`);
-                await TaskService.revokeTask(user, task, 202, `Expected user ${user} to have access to revoke task ${taskName}`);
-            }
-        };
-
-        for (const user of others) {
-            console.log(`\nChecking whether user ${user} is allowed to manage task ${taskName}`);
-            await TaskService.assignTask(user, task, assignee, 401, `Not expected that user ${user} is allowed to manage task ${taskName}`);
         };
     }
 }

--- a/src/tests/api/caseteam/testcaseteamtaskauthorizations.ts
+++ b/src/tests/api/caseteam/testcaseteamtaskauthorizations.ts
@@ -1,6 +1,8 @@
 'use strict';
 
+import Case from '../../../cmmn/case';
 import Definitions from '../../../cmmn/definitions/definitions';
+import Task from '../../../cmmn/task';
 import TaskState from '../../../cmmn/taskstate';
 import CaseTeam from '../../../cmmn/team/caseteam';
 import CaseTeamUser, { CaseOwner } from "../../../cmmn/team/caseteamuser";
@@ -46,10 +48,25 @@ export default class TestCaseTeamTaskAuthorizations extends TestCase {
         const assistTask = findTask(tasks, 'Assist');
         const taskWithoutRole = findTask(tasks, 'Task Without Role');
 
+        await this.runApproveTaskOperations(approveTask, caseInstance);
+        await this.runRequestTaskOperations(requestTask, caseInstance);
+        await this.runAssistTaskOperations(assistTask, caseInstance);
+
+
+        // Receiver can also complete the Task Without Role task eventhough receiver is not case owner
+        await TaskService.completeTask(receiver, taskWithoutRole, {});
+        await assertTask(receiver, taskWithoutRole, 'Complete', TaskState.Completed, receiver, receiver);        
+    }
+
+    async runApproveTaskOperations(approveTask: Task, caseInstance: Case) {
         // Although sender didn't have appropriate roles;
         // Sender can claim Approve task, as sender is owner
         await TaskService.claimTask(sender, approveTask);
         await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, sender, sender);
+
+        // Now, Approve task can be claimed by receiver (as a member who have appropriate roles)
+        await TaskService.claimTask(receiver, approveTask);
+        await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, receiver, receiver);
 
         // Sender can revoke Approve task
         await TaskService.revokeTask(sender, approveTask);
@@ -59,139 +76,169 @@ export default class TestCaseTeamTaskAuthorizations extends TestCase {
         await TaskService.claimTask(receiver, approveTask);
         await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, receiver, receiver);
 
-        // Employee is not part of the case team
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee), false);
+        // Verify that employee gets added to the caseteam with the right role
+        await this.verifyCaseTeamChangeThroughDelegationAndAssignment(approveTask, caseInstance);
 
-        // Although employee doesn't have appropriate roles and not part of the team;
-        // Sender can delegate Approve task to employee (receiver perspective)
-        await TaskService.delegateTask(sender, approveTask, employee);
-        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, employee, receiver);
-
-        // Now, employee is part of the case team with Approver role
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [approverRole]));
-
-        // Employee cannot claim the Approve task; because Approve task is delegated
-        await TaskService.claimTask(employee, approveTask, 400, 'Employee cannot claim the Approve task; because Approve task is delegated');
-        await assertTask(sender, approveTask, 'Claim', TaskState.Delegated, employee, receiver);
-
-        // Sender can revoke the Approve task (employee perspective)
-        await TaskService.revokeTask(sender, approveTask);
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Assigned, receiver, receiver);
-
-        // Sender can revoke the Approve task (receiver perspective)
-        await TaskService.revokeTask(sender, approveTask);
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Unassigned, User.NONE, User.NONE);
-
-        // Sender can remove Approve role from employee
+        // Now remove Approve role from employee and verify access to the task operations
         await CaseTeamService.setUser(sender, caseInstance, new CaseTeamUser(employee, []));
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee));
-
-        // Now, employee cannot perform save the Approve task output as employee lack approriate role
-        await TaskService.saveTaskOutput(employee, approveTask, {}, 401, 'Employee should not be able to save the Approve task output as employee lack approriate role');
-        await assertTask(employee, approveTask, 'Save', TaskState.Unassigned, User.NONE, User.NONE);
-
-        // Approve task can be assigned to employee by sender (although he don't have appropriate roles)
-        await TaskService.assignTask(sender, approveTask, employee);
-        await assertTask(sender, approveTask, 'Assign', TaskState.Assigned, employee, employee);
-
-        // Now, employee gets the Approve role as sender is assigned task to employee
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [approverRole]));
-
-        // Sender don't have the Approver role
-        await assertCaseTeamUser(sender, caseInstance, new CaseOwner(sender));
-
-        // Employee delegates the Approve task to sender
-        await TaskService.delegateTask(employee, approveTask, sender);
-        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, sender, employee);
-
-        // Now, sender should not get the Approver role (as Sender is owner)
-        await assertCaseTeamUser(sender, caseInstance, new CaseOwner(sender, []));
-
-        // Sender should not be able to claim the Approve task as sender is delegated to it
-        await TaskService.claimTask(sender, approveTask, 400, 'Sender should not be able to claim the Approve task as sender is delegated to it');
-        await assertTask(sender, approveTask, 'Claim', TaskState.Delegated, sender, employee);
-
-        // Sender revokes the Approve task
-        await TaskService.revokeTask(sender, approveTask);
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Assigned, employee, employee);
-
-        // Receiver should not be able to delegate Approve task to sender
-        await TaskService.delegateTask(receiver, approveTask, sender, 401, 'Receiver should not be able to delegate Approve task to sender');
-        await assertTask(sender, approveTask, 'Assign', TaskState.Assigned, employee, employee);
-
-        // Sender delegates the Approve task to receiver (employee perspective)
-        await TaskService.delegateTask(sender, approveTask, receiver);
-        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, receiver, employee);
-
-        // Receiver should not be able to claim the Approve task, as Approve task is delegated to receiver itself
-        await TaskService.claimTask(receiver, approveTask, 400, 'Receiver should not be able to claim the Approve task, as Approve task is delegated to receiver itself');
-        await assertTask(sender, approveTask, 'Claim', TaskState.Delegated, receiver, employee);
-
-        // Receiver can revoke the Approve task
-        await TaskService.revokeTask(receiver, approveTask);
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Assigned, employee, employee);
-
-        // Sender can delegate the Approve task to sender itself
-        await TaskService.delegateTask(sender, approveTask, sender);
-        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, sender, employee);
-
-        // Although employee is the owner of the Approve task, should not be able to revoke it
-        await TaskService.revokeTask(employee, approveTask, 401, 'Although employee is the owner of the Approve task, should not be able to revoke it');
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Delegated, sender, employee);
-
-        // Sender can revoke the Approve task
-        await TaskService.revokeTask(sender, approveTask);
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Assigned, employee, employee);
-
-        // Employee revokes the Approve task
-        await TaskService.revokeTask(employee, approveTask);
-        await assertTask(sender, approveTask, 'Revoke', TaskState.Unassigned, User.NONE, User.NONE);
-
-        // Although employee revokes the task, the Approver role is present with employee itself
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [approverRole]));
-
-        // Employee can claim the Approve task (without help of sender)
-        await TaskService.claimTask(employee, approveTask);
-        await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, employee, employee);
-
-        // Employee can delegate the Approve task to receiver
-        await TaskService.delegateTask(employee, approveTask, receiver);
-        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, receiver, employee);
+        await this.verifyEmployeeNoLongerHasTaskAccess(approveTask, caseInstance);
 
         // Check receiver's roles in the case team
         await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(receiver, [approverRole, paRole, requestorRole]));
 
-        // Finally receiver can complete the Approve task
-        await TaskService.completeTask(receiver, approveTask);
-        await assertTask(sender, approveTask, 'Complete', TaskState.Completed, receiver, employee);
+        // Check delegation lifecycle validations
+        await this.verifyCanDelegateUnassignedAndDelegatedTask(approveTask, caseInstance);
 
-        const notExistingTenantUserId = `I'm not in the tenant`;
+        // Finally complete the Approve task, and check that delegated task can be completed without having the case role
+        await this.completeDelegatedTaskWithoutCaseRole(approveTask, caseInstance);
+    }
 
-        // Sender should not be able to assign Request task to false-user who is not in the team
-        await TaskService.assignTask(employee, requestTask, new TenantUser(notExistingTenantUserId), 401, 'Employee should not be able to assign Request task as he is not case owner');
-        await assertTask(sender, requestTask, 'Delegate', TaskState.Unassigned, User.NONE, User.NONE);
+    async verifyCaseTeamChangeThroughDelegationAndAssignment(approveTask: Task, caseInstance: Case) {
+        // First verify that employee is not part of the case team
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee), false);
+        // Also verify that employee cannot get the task
+        await TaskService.getTask(employee, approveTask, 404);
 
-        // Sender should not be able to delegate Request task to false-user who is not in the team
-        await TaskService.delegateTask(employee, requestTask, new TenantUser(notExistingTenantUserId), 401, 'Employee should not be able to delegate Request task as he is not case owner');
-        await assertTask(sender, requestTask, 'Delegate', TaskState.Unassigned, User.NONE, User.NONE);
+        // Do an extra task assertion so that it is clear here in the test code what the expected task state
+        await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, receiver, receiver);
 
-        // As the task is not delegated false-user cannot be part of the case team
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(notExistingTenantUserId), false);
+        // Since employee is not part of the case team, receiver cannot delegate the task
+        await TaskService.delegateTask(receiver, approveTask, employee, 400);
+        await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, receiver, receiver);
 
-        // Sender can remove employee from case team
+        // Although employee doesn't have appropriate roles and not part of the team;
+        // Sender can delegate Approve task to employee - but without employee getting the 'Approver' role
+        await TaskService.delegateTask(sender, approveTask, employee);
+        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, employee, receiver);
+
+        // Now, employee is part of the case team but without the Approver role
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, []));
+
+        // Check that employee cannot delegate the task to someone else
+        await TaskService.delegateTask(employee, approveTask, receiver, 401);
+        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, employee, receiver);
+
+        // Employee can revoke the task, and still should not have the role in the case team
+        await TaskService.revokeTask(employee, approveTask);
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, []));
+        await assertTask(sender, approveTask, 'Revoke', TaskState.Assigned, receiver, receiver);
+
+        // After the employee revoked, employee should not be able to claim the task
+        await TaskService.claimTask(employee, approveTask, 401);
+        await assertTask(sender, approveTask, 'Revoke', TaskState.Assigned, receiver, receiver);
+
+        // If Sender assigns instead of delegates the task to employee, then employee should get the approver role and also own the task
+        await TaskService.assignTask(sender, approveTask, employee);
+        await assertTask(sender, approveTask, 'Assign', TaskState.Assigned, employee, employee);
+        
+        // Now, employee is part of the case team with Approver role
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [approverRole]));
+
+        // Employee can revoke the task, and should still have the role in the case team
+        await TaskService.revokeTask(employee, approveTask);
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [approverRole]));
+
+        // Therefore, Employee can also claim the task again
+        await TaskService.claimTask(employee, approveTask);
+        await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, employee, employee);
+
+        // Sender can revoke the Approve task
+        await TaskService.revokeTask(sender, approveTask);
+        await assertTask(sender, approveTask, 'Revoke', TaskState.Unassigned);        
+    }
+
+    async verifyEmployeeNoLongerHasTaskAccess(approveTask: Task, caseInstance: Case) {
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee));
+
+        // Now, employee cannot perform save the Approve task output as employee lack approriate role
+        await TaskService.saveTaskOutput(employee, approveTask, {}, 401, 'Employee should not be able to save the Approve task output as employee lack approriate role');
+        await TaskService.claimTask(employee, approveTask, 401, 'Employee cannot claim the Approve task as employee lacks the approriate role');
+        await TaskService.assignTask(employee, approveTask, sender, 401, 'Employee cannot assign the Approve task as employee lacks the approriate role');
+        await TaskService.revokeTask(employee, approveTask, 401, 'Employee cannot revoke the Approve task as employee lacks the approriate role');
+        await TaskService.delegateTask(employee, approveTask, sender, 401, 'Employee cannot delegate the Approve task as employee lacks the approriate role');
+
+        // Assert that the task is still in same state.
+        await assertTask(employee, approveTask, 'Save, Claim, Assign, Revoke and Delegate', TaskState.Unassigned, User.NONE, User.NONE, sender);
+    }
+
+    async verifyCaseOwnerDoesNotGetCaseRoles(approveTask: Task, caseInstance: Case) {
+        // Verify that sender is owner and doesn't have the Approver role
+        await assertCaseTeamUser(sender, caseInstance, new CaseOwner(sender));
+
+        // Let receiver claim the task.
+        await TaskService.claimTask(receiver, approveTask);//, 400, 'Sender should not be able to claim the Approve task as sender is delegated to it');
+
+        // Receiver delegates the Approve task to sender
+        await TaskService.delegateTask(receiver, approveTask, sender);
+        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, sender, receiver);
+
+        // Now, sender should not get the Approver role (as Sender is owner)
+        await assertCaseTeamUser(sender, caseInstance, new CaseOwner(sender, []));
+
+        // Revoke task back to receiver
+        await TaskService.revokeTask(receiver, approveTask);
+        await assertTask(receiver, approveTask, 'Revoke', TaskState.Assigned, receiver, receiver);
+
+        // Show that when assigning the task also the sender does not get the role
+        await TaskService.assignTask(receiver, approveTask, sender);
+        await assertCaseTeamUser(receiver, caseInstance, new CaseOwner(sender, []));
+        await TaskService.revokeTask(sender, approveTask);        
+        await assertCaseTeamUser(receiver, caseInstance, new CaseOwner(sender, []));
+        
+        // Show that when claiming the task also the sender does not get the role
+        await TaskService.claimTask(sender, approveTask);
+        await assertCaseTeamUser(receiver, caseInstance, new CaseOwner(sender, []));
+        await assertTask(sender, approveTask, 'Claim', TaskState.Assigned, sender, sender);
+
+        // Sender revokes the Approve task
+        await TaskService.revokeTask(sender, approveTask);
+        await assertTask(sender, approveTask, 'Revoke', TaskState.Unassigned);
+    }
+    
+    async verifyCanDelegateUnassignedAndDelegatedTask(approveTask: Task, caseInstance: Case) {
+        // Receiver should not be able to delegate Approve task to sender
+        await TaskService.delegateTask(receiver, approveTask, sender);
+        await assertTask(sender, approveTask, 'Delete', TaskState.Delegated, sender);
+
+        // Sender delegates the Approve task to receiver (employee perspective)
+        await TaskService.delegateTask(sender, approveTask, receiver);
+        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, receiver);
+    }
+    
+    async completeDelegatedTaskWithoutCaseRole(approveTask: Task, caseInstance: Case) {
+        // Verify that employee does not have any roles in the case team
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, []));
+
+        await TaskService.claimTask(receiver, approveTask);
+        await TaskService.delegateTask(receiver, approveTask, employee);
+
+        await assertTask(sender, approveTask, 'Delegate', TaskState.Delegated, employee, receiver);
+
+        // Again, even though task is delegated, employee should not have any roles.
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, []));
+
+        await TaskService.completeTask(employee, approveTask);
+        await assertTask(sender, approveTask, 'Complete', TaskState.Completed, employee, receiver, employee);
+    }
+
+    async runRequestTaskOperations(requestTask: Task, caseInstance: Case) {
+        await this.verifyCannotAssignOutsideUsersWhenNotOwner(requestTask, caseInstance);
+
+        // Let's now remove employee from the team
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee));
         await CaseTeamService.removeUser(sender, caseInstance, employee);
-        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [approverRole]), false);
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee), false);
 
         // Sender can assign Request task to employee (who is not part of the team)
         await TaskService.assignTask(sender, requestTask, employee);
-        await assertTask(sender, requestTask, 'Assign', TaskState.Assigned, employee, employee);
+        await assertTask(sender, requestTask, 'Assign', TaskState.Assigned, employee, employee, sender);
 
         // Now, employee is part of the team with Requestor role
         await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [requestorRole]));
 
         // Receiver should not be able to assign to itself the Request task (although receiver has appropriate role)
-        await TaskService.assignTask(receiver, requestTask, receiver, 401, 'Receiver should not be able to assign to itself the Request task (although receiver has appropriate role)');
-        await assertTask(sender, requestTask, 'Assign', TaskState.Assigned, employee, employee);
+        await TaskService.assignTask(receiver, requestTask, receiver);
+        await assertTask(sender, requestTask, 'Assign', TaskState.Assigned, receiver, receiver);
 
         // But, sender can assign to itself the Request task (as sender is owner)
         await TaskService.assignTask(sender, requestTask, sender);
@@ -225,7 +272,24 @@ export default class TestCaseTeamTaskAuthorizations extends TestCase {
         // Again, sender removes the employee from the team
         await CaseTeamService.removeUser(sender, caseInstance, employee);
         await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [requestorRole]), false);
+    }
 
+    async verifyCannotAssignOutsideUsersWhenNotOwner(requestTask: Task, caseInstance: Case) {
+        const notExistingTenantUserId = `I'm not in the tenant`;
+
+        // Sender should not be able to assign Request task to false-user who is not in the team
+        await TaskService.assignTask(employee, requestTask, new TenantUser(notExistingTenantUserId), 401, 'Employee should not be able to assign Request task as he is not case owner');
+        await assertTask(sender, requestTask, 'Delegate', TaskState.Unassigned, User.NONE, User.NONE);
+
+        // Sender should not be able to delegate Request task to false-user who is not in the team
+        await TaskService.delegateTask(employee, requestTask, new TenantUser(notExistingTenantUserId), 401, 'Employee should not be able to delegate Request task as he is not case owner');
+        await assertTask(sender, requestTask, 'Delegate', TaskState.Unassigned, User.NONE, User.NONE);
+
+        // As the task is not delegated false-user cannot be part of the case team
+        await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(notExistingTenantUserId), false);
+    }
+
+    async runAssistTaskOperations(assistTask: Task, caseInstance: Case) {
         // Sender can assign Assist task to employee (who is not part of the team)
         await TaskService.assignTask(sender, assistTask, employee);
         await assertTask(sender, assistTask, 'Assign', TaskState.Assigned, employee, employee);
@@ -233,22 +297,22 @@ export default class TestCaseTeamTaskAuthorizations extends TestCase {
         // Now, employee is part of the team with PA role
         await assertCaseTeamUser(sender, caseInstance, new CaseTeamUser(employee, [paRole]));
 
-        // Receiver should not be able to complete the Assist task which is assigned to employee
-        await TaskService.completeTask(receiver, assistTask, {}, 401, 'Receiver should not be able to complete the Assist task which is assigned to employee');
-        await assertTask(sender, assistTask, 'Complete', TaskState.Assigned, employee, employee);
+        // Sender removes the paRole from receiver
+        await CaseTeamService.setUser(sender, caseInstance, new CaseTeamUser(receiver, [approverRole, requestorRole]));
+
+        // Receiver should not be able to complete the assigned task because receiver doesn't have appropriate role
+        await TaskService.completeTask(receiver, assistTask, {}, 401, 'Receiver should not be able to complete the assigned task because receiver doesn\'t have appropriate role');
+        await assertTask(sender, assistTask, 'Assign', TaskState.Assigned, employee, employee);
 
         // Employee revokes the assist task
         await TaskService.revokeTask(employee, assistTask);
         await assertTask(sender, assistTask, 'Revoke', TaskState.Unassigned, User.NONE, User.NONE);
 
-        // Sender removes the paRole from receiver
-        await CaseTeamService.setUser(sender, caseInstance, new CaseTeamUser(receiver, [approverRole, requestorRole]));
-
         // Receiver should not be able to complete the unassigned task because receiver doesn't have appropriate role
         await TaskService.completeTask(receiver, assistTask, {}, 401, 'Receiver should not be able to complete the unassigned task because receiver doesn\'t have appropriate role');
-        await assertTask(sender, assistTask, 'Complete', TaskState.Unassigned, User.NONE, User.NONE);
+        await assertTask(sender, assistTask, 'Assign', TaskState.Unassigned, User.NONE, User.NONE);
 
-        // Employee can save the Assist task output
+        // Employee can still save the Assist task output
         await TaskService.saveTaskOutput(employee, assistTask, {});
         await assertTask(employee, assistTask, 'Save', TaskState.Unassigned, User.NONE, User.NONE);
 
@@ -259,8 +323,10 @@ export default class TestCaseTeamTaskAuthorizations extends TestCase {
         // Sender should not get PA role
         await assertCaseTeamUser(sender, caseInstance, new CaseOwner(sender, []));
 
-        // Neither employee nor receiver should not be able to complete the task which is assigned to sender
-        await TaskService.completeTask(employee, assistTask, {}, 401, 'Employee should not be able to complete the task which is assigned to sender');
+        // Employee can still save the Assist task output, even though task is assigned to sender
+        await TaskService.saveTaskOutput(employee, assistTask, {});
+
+        // Receiver should not be able to complete the task which is assigned to sender
         await TaskService.completeTask(receiver, assistTask, {}, 401, 'Receiver should not be able to complete the task which is assigned to sender');
         await assertTask(sender, assistTask, 'Claim', TaskState.Assigned, sender, sender);
 
@@ -272,8 +338,5 @@ export default class TestCaseTeamTaskAuthorizations extends TestCase {
         await TaskService.completeTask(employee, assistTask);
         await assertTask(sender, assistTask, 'Complete', TaskState.Completed, employee, employee);
 
-        // Receiver can also complete the Task Without Role task eventhough receiver is not case owner
-        await TaskService.completeTask(receiver, taskWithoutRole, {});
-        await assertTask(receiver, taskWithoutRole, 'Complete', TaskState.Completed, receiver, receiver);
     }
 }

--- a/src/tests/api/caseteam/testcaseteamtaskauthorizationsforgroups.ts
+++ b/src/tests/api/caseteam/testcaseteamtaskauthorizationsforgroups.ts
@@ -1,0 +1,84 @@
+'use strict';
+
+import Definitions from '../../../cmmn/definitions/definitions';
+import TaskState from '../../../cmmn/taskstate';
+import CaseTeam from '../../../cmmn/team/caseteam';
+import CaseTeamGroup, { GroupRoleMappingWithCaseOwnership } from '../../../cmmn/team/caseteamgroup';
+import CaseService from '../../../service/case/caseservice';
+import ConsentGroup from '../../../service/consentgroup/consentgroup';
+import ConsentGroupMember, { ConsentGroupOwner } from '../../../service/consentgroup/consentgroupmember';
+import ConsentGroupService from '../../../service/consentgroup/consentgroupservice';
+import PlatformService from '../../../service/platform/platformservice';
+import TaskService from '../../../service/task/taskservice';
+import Tenant from '../../../tenant/tenant';
+import { TenantOwner } from '../../../tenant/tenantuser';
+import { assertTask, findTask } from '../../../test/caseassertions/task';
+import TestCase from '../../../test/testcase';
+import Util from '../../../test/util';
+import User from '../../../user';
+
+const definition = Definitions.CaseTeam;
+const adminUser1 = new TenantOwner('adminUser1');
+const adminUser2 = new TenantOwner('adminUser2');
+const employeeUser = new TenantOwner('employeeUser');
+
+const groupRoleAdmin = 'Admin';
+const groupRoleEmployee = 'Employee';
+
+const tenant = new Tenant(Util.generateId('tenant-'), [adminUser1, adminUser2, employeeUser]);
+const groupId = Util.generateId('group-');
+const group = new ConsentGroup([new ConsentGroupOwner(adminUser1.id, [groupRoleAdmin]), new ConsentGroupMember(adminUser2.id, [groupRoleAdmin]), new ConsentGroupMember(employeeUser.id, [groupRoleEmployee])], groupId);
+
+const caseRoleRequestor = "Requestor";
+const caseRoleApprover = "Approver";
+const caseRolePA = "PersonalAssistant";
+
+
+const groupMembershipMappingAdmin = new GroupRoleMappingWithCaseOwnership(groupRoleAdmin, [caseRoleApprover, caseRoleRequestor, caseRolePA]);
+const groupMembershipMappingEmployee = new GroupRoleMappingWithCaseOwnership(groupRoleEmployee, [caseRoleApprover, caseRoleRequestor, caseRolePA]);
+
+const caseTeamGroup = new CaseTeamGroup(groupId, [groupMembershipMappingAdmin, groupMembershipMappingEmployee]);
+
+
+export default class TestCaseTeamTaskAuthorizationsForGroups extends TestCase {
+    async onPrepareTest() {
+        const admin = new User('admin');
+        await admin.login();
+        await PlatformService.createTenant(admin, tenant);
+        await adminUser1.refreshToken();
+        await definition.deploy(adminUser1, tenant);
+        await ConsentGroupService.createGroup(adminUser1, tenant, group);
+        await adminUser2.refreshToken();
+        await employeeUser.refreshToken();
+    }
+
+    async run() {
+        const caseTeam = new CaseTeam([], [caseTeamGroup]);
+        const startCase = { tenant, definition, debug: true, caseTeam };
+        await ConsentGroupService.getGroup(adminUser1, groupId)
+        const caseInstance = await CaseService.startCase(adminUser1, startCase);
+        this.addIdentifier(caseInstance);
+
+        // Get case tasks should be possible for sender
+        const tasks = await TaskService.getCaseTasks(adminUser1, caseInstance);
+        const approveTask = findTask(tasks, 'Approve');
+
+        await TaskService.claimTask(adminUser1, approveTask);
+        await assertTask(adminUser1, approveTask, 'Claim', TaskState.Assigned, adminUser1, adminUser1);
+
+        await TaskService.revokeTask(adminUser1, approveTask);
+        await assertTask(adminUser1, approveTask, 'Revoke', TaskState.Unassigned, User.NONE, User.NONE);
+
+        await TaskService.claimTask(adminUser2, approveTask);
+        await assertTask(adminUser1, approveTask, 'Claim', TaskState.Assigned, adminUser2, adminUser2);
+
+        await TaskService.claimTask(employeeUser, approveTask);
+        await assertTask(adminUser1, approveTask, 'Claim', TaskState.Assigned, employeeUser, employeeUser);
+
+        await TaskService.assignTask(employeeUser, approveTask, adminUser2);
+        await assertTask(adminUser1, approveTask, 'Assign', TaskState.Assigned, adminUser2, adminUser2);
+
+        // Admin1 can revoke the Approve task (employee perspective)
+        await TaskService.completeTask(adminUser1, approveTask);
+    }
+}

--- a/src/tests/incidentmanagement/incidentmanagement.ts
+++ b/src/tests/incidentmanagement/incidentmanagement.ts
@@ -132,7 +132,7 @@ Starting another case instance of incident management to test Invalid status.
         await verifyTaskInput(workOnIncidentTask, secondTaskInput);
 
         // Can't claim Work on Incident task by solver as he is assigned to it
-        await TaskService.claimTask(solver, workOnIncidentTask, 400);
+        // await TaskService.claimTask(solver, workOnIncidentTask, 400);
         await assertTask(raiser, workOnIncidentTask, 'Claim', TaskState.Assigned, solver, solver);
 
         const finalTaskOutput = IncidentContent.finalTaskOutput;
@@ -192,4 +192,3 @@ Starting another case instance of incident management to test Invalid status.
         await assertPlanItem(raiser, caseInstance, 'Complete', 0, State.Available);
     }
 }
-


### PR DESCRIPTION
E.g. case users can now take over an already claimed task when they have the appropriate role